### PR TITLE
Set-deploy-credentials, plus set and list azure accounts

### DIFF
--- a/machines/list-azure-accounts.js
+++ b/machines/list-azure-accounts.js
@@ -1,0 +1,45 @@
+module.exports = {
+  friendlyName: 'Sets Site Deployment Credentials',
+  description: 'Sets the deployment credntials of an Azure website',
+  
+  extendedDescription: '',
+  inputs: {},
+  defaultExit: 'success',
+  exits: { 
+    error: { 
+      description: 'Unexpected error occurred.' 
+    },
+    success: { 
+      description: 'Done.' 
+    } 
+  },
+
+  fn: function (inputs,exits) {
+
+    var cliPath = require('path').resolve(__dirname, '../node_modules/azure-cli/bin/azure');
+    var scripty = require('azure-scripty');
+    
+    var command = {
+      cmd: 'account list'
+    };
+
+    scripty.invoke(command, function (err, subscriptions) {
+
+      if(err){
+        return exits.error(err);
+      }
+
+      var output = [];
+      for(var i in subscriptions){
+        output.push({
+          id: subscriptions[i].id,
+          name: subscriptions[i].name
+        });
+      }
+
+      return exits.success(output);
+    });
+
+  }
+
+};

--- a/machines/set-deploy-credentials.js
+++ b/machines/set-deploy-credentials.js
@@ -1,15 +1,20 @@
 module.exports = {
-  friendlyName: 'Set Azure Account',
-  description: 'Sets the active azure subscription',
+  friendlyName: 'Sets Site Deployment Credentials',
+  description: 'Sets the deployment credntials of an Azure website',
+  
   extendedDescription: '',
   inputs: {
-    subNameOrId: {
-      description: 'The subscription id or name to set as active',
+    deploymentUser: {
+      description: 'The Name of the User',
       example: 'johndoe',
+      required: true
+    },
+    deploymentPassword: {
+      description: 'The deployment password',
+      example: 'p@ssword',
       required: true
     }
   },
-
   defaultExit: 'success',
   exits: { 
     error: { 
@@ -19,15 +24,13 @@ module.exports = {
       description: 'Done.' 
     } 
   },
-  
+
   fn: function (inputs,exits) {
     var child_process = require('child_process');
-    var inquirer = require('inquirer');
     var cliPath = require('path').resolve(__dirname, '../node_modules/azure-cli/bin/azure');
-    
-    var command = 'node ' + cliPath + ' account set ' + inputs.subNameOrId;
 
-    child_process.exec(command, function(err, stdout){
+    var command = 'node ' + cliPath + ' site deployment user set ' + inputs.deploymentUser + ' ' + inputs.deploymentPassword;
+    child_process.exec(command, function (err, stdout) {
 
       if(err){
         return exits.error(err);
@@ -35,5 +38,7 @@ module.exports = {
 
       return exits.success();
     });
+
   }
+
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "azure-cli": "^0.8.14",
     "azure-mgmt-compute": "^0.9.14",
+    "azure-scripty": "^1.0.1",
     "inquirer": "^0.8.0",
     "lodash": "^3.0.0",
     "machine": "^2.0.0",
@@ -59,7 +60,9 @@
       "trigger-webjob",
       "info-webjob",
       "log-webjob",
-      "upload-file"
+      "upload-file",
+      "set-deploy-credentials",
+      "list-azure-accounts"
     ],
     "testsUrl": "https://travis-ci.org/balderdashy/machinepack-azure"
   }


### PR DESCRIPTION
3 new machines to set deploy credentials, list and set active azure account.

Set-deploy-credentials depends on [this PR](https://github.com/Azure/azure-sdk-for-node/pull/1381). Seems like theres a bug in one of the azure sdks for setting the deployment git credentials.
